### PR TITLE
prevent out of bounds index < 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = remove
 
 function remove (arr, i) {
-  if (i >= arr.length) return
+  if (i >= arr.length || i < 0) return
   var last = arr.pop()
   if (i < arr.length) {
     var tmp = arr[i]

--- a/test.js
+++ b/test.js
@@ -16,5 +16,7 @@ tape('out of bounds', function (t) {
   var list = [0, 1, 2]
   remove(list, 42)
   t.same(list, [0, 1, 2])
+  remove(list, -1)
+  t.same(list, [0, 1, 2])
   t.end()
 })


### PR DESCRIPTION
This is really useful for removing items only if they are found in the array:

``` js
var arr = ['a', 'b', 'c']
remove(arr, arr.indexOf('d'))
arr // ['a', 'b', 'c']
```
