### PR TITLE
Check element equality before replacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = remove
 function remove (arr, i) {
   if (i >= arr.length || i < 0) return
   var last = arr.pop()
-  if (i < arr.length) {
+  if (i < arr.length && arr[i] !== last) {
     var tmp = arr[i]
     arr[i] = last
     return tmp


### PR DESCRIPTION
This one is probably trash.

The change:  Check whether the element replaced with the popped tail is `===` to the current value.

It makes sense with the kinds of examples in `README` and `test.js`, with `String`, `Number`, and other value-type elements.

In practice, I suspect this condition will almost never skip the allocation-replace-return.  So not worth it.